### PR TITLE
E02 t04 protect backend routes

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -27,7 +27,10 @@ const start = async (): Promise<void> => {
       TagResolver,
     ],
     authChecker: ({ context }) => {
-      if (context.email === undefined) return false
+      const {
+        userFromToken: { email },
+      } = context
+      if (email === undefined) return false
       else return true
     },
   })
@@ -43,8 +46,8 @@ const start = async (): Promise<void> => {
         try {
           const bearer = req.headers.authorization
           if (bearer.length > 0) {
-            const user = jwt.verify(bearer, process.env.JWT_SECRET_KEY)
-            return user
+            const userFromToken = jwt.verify(bearer, process.env.JWT_SECRET_KEY)
+            return { userFromToken }
           } else {
             return {}
           }

--- a/src/resolvers/blogResolver.ts
+++ b/src/resolvers/blogResolver.ts
@@ -1,4 +1,4 @@
-import { Arg, Mutation, Query, Resolver } from 'type-graphql'
+import { Arg, Ctx, Mutation, Query, Resolver } from 'type-graphql'
 import dataSource from '../utils'
 import { Blog } from '../entities/Blog'
 import { User } from '../entities/User'
@@ -42,13 +42,13 @@ export class BlogResolver {
 
   @Mutation(() => Blog)
   async createBlog(
+    @Ctx() context: { userId: string; email: string },
     @Arg('name') name: string,
     @Arg('description') description: string,
-    @Arg('userId') userId: string,
     @Arg('template', { nullable: true }) template?: string
   ): Promise<Blog> {
     try {
-      // TODO : Get user from token
+      const { userId } = context
       const user = await dataSource.manager.findOneByOrFail(User, {
         id: userId,
       })

--- a/src/resolvers/categoryResolver.ts
+++ b/src/resolvers/categoryResolver.ts
@@ -1,9 +1,10 @@
-import { Arg, Mutation, Resolver } from 'type-graphql'
+import { Arg, Authorized, Mutation, Resolver } from 'type-graphql'
 import dataSource from '../utils'
 import { Category } from '../entities/Category'
 
 @Resolver(Category)
 export class CategoryResolver {
+  @Authorized()
   @Mutation(() => Category)
   async createCategory(@Arg('name') name: string): Promise<Category> {
     try {

--- a/src/resolvers/commentResolver.ts
+++ b/src/resolvers/commentResolver.ts
@@ -1,22 +1,30 @@
-import { Arg, Mutation, Resolver } from 'type-graphql'
+import { Arg, Authorized, Ctx, Mutation, Resolver } from 'type-graphql'
 import { Article } from '../entities/Article'
 import { Comment } from '../entities/Comment'
+import { User } from '../entities/User'
 import dataSource from '../utils'
 
 @Resolver(Comment)
 export class CommentResolver {
+  @Authorized()
   @Mutation(() => Comment)
   async commentArticle(
+    @Ctx() context: { userId: string; email: string },
     @Arg('content') content: string,
     @Arg('articleId') articleId: string
   ): Promise<Comment> {
     try {
+      const { userId } = context
+      const user = await dataSource.manager.findOneByOrFail(User, {
+        id: userId,
+      })
       const newComment = new Comment()
       newComment.content = content
       const article = await dataSource.manager.findOneByOrFail(Article, {
         id: articleId,
       })
       newComment.article = article
+      newComment.user = user
 
       const newCommentFromDB = await dataSource.manager.save(newComment)
       return newCommentFromDB

--- a/src/resolvers/tagResolver.ts
+++ b/src/resolvers/tagResolver.ts
@@ -1,9 +1,10 @@
-import { Arg, Mutation, Resolver } from 'type-graphql'
+import { Arg, Authorized, Mutation, Resolver } from 'type-graphql'
 import dataSource from '../utils'
 import { Tag } from '../entities/Tag'
 
 @Resolver(Tag)
 export class TagResolver {
+  @Authorized()
   @Mutation(() => Tag)
   async createTag(@Arg('name') name: string): Promise<Tag> {
     try {

--- a/src/resolvers/userResolver.ts
+++ b/src/resolvers/userResolver.ts
@@ -77,6 +77,10 @@ export class UserResolver {
           { email: userFromDB.email, userId: userFromDB.id },
           process.env.JWT_SECRET_KEY
         )
+
+        userFromDB.lastLogin = new Date()
+        await dataSource.manager.save(userFromDB)
+
         const user = new LoginResponse()
         user.user = userFromDB
         user.token = token

--- a/src/resolvers/userResolver.ts
+++ b/src/resolvers/userResolver.ts
@@ -16,7 +16,7 @@ import jwt from 'jsonwebtoken'
 class LoginResponse {
   @Field()
   token: string
-  
+
   @Field(() => User)
   user: User
 }
@@ -74,7 +74,7 @@ export class UserResolver {
 
       if (await argon2.verify(userFromDB.password, password)) {
         const token = jwt.sign(
-          { email: userFromDB.email },
+          { email: userFromDB.email, userId: userFromDB.id },
           process.env.JWT_SECRET_KEY
         )
         const user = new LoginResponse()


### PR DESCRIPTION
# TASK TO EPIC PR

## The feature / The problem
- The auth checker wasn't working as expected after implementation. It was checking for email in context object but needed to retrieve the email value from `context.user.email` 
- No routes were protected up until these changes.

## What I've done / The solution
- First fix the auth checker by destructuring the `context` object to get `userFromToken.email`  
- Protect every route that needs to be protected with the `@Authorized()` decorator

## Scope of my changes
- src/index.ts
- src/resolvers/articleResolver.ts
- src/resolvers/blogResolver.ts
- src/resolvers/categoryResolver.ts
- src/resolvers/commentResolver.ts
- src/resolvers/tagResolver.ts
- src/resolvers/userResolver.ts

## Task
- [e02-t04_protect-backend-routes](https://enchanting-triangle-00d.notion.site/e02-t04_protect-backend-routes-a535925c6799412c9929a3cb0632ff80)

## Type of change
- [x] New feature (feat)
- [x] Fix issue (fix)
- [ ] Code refactorisation (refactor)
- [ ] Code testing (test)
- [ ] Add documentation (docs)


# Checklist
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my PR
- [x] I have removed not needed logs
- [x] I have remover TODO comments
- [ ] I have commented in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation

- [x] I have been able to build my solution locally
- [x] My changes generate no new warnings

- [ ] New and existing unit tests pass locally with my changes

# Communication