### PR TITLE
:sparkles:feat(e04-t08): add field slug to blogs

### DIFF
--- a/src/entities/Blog.ts
+++ b/src/entities/Blog.ts
@@ -31,6 +31,10 @@ export class Blog {
   template: number
 
   @Field()
+  @Column({ type: 'varchar', unique: true })
+  slug: string
+
+  @Field()
   @CreateDateColumn({ type: 'timestamp with time zone' })
   createdAt: Date
 

--- a/src/migrations/1675089320456-BlogsSlug.ts
+++ b/src/migrations/1675089320456-BlogsSlug.ts
@@ -1,0 +1,16 @@
+import { MigrationInterface, QueryRunner } from "typeorm";
+
+export class BlogsSlug1675089320456 implements MigrationInterface {
+    name = 'BlogsSlug1675089320456'
+
+    public async up(queryRunner: QueryRunner): Promise<void> {
+        await queryRunner.query(`ALTER TABLE "blog" ADD "slug" character varying NOT NULL`);
+        await queryRunner.query(`ALTER TABLE "blog" ADD CONSTRAINT "UQ_0dc7e58d73a1390874a663bd599" UNIQUE ("slug")`);
+    }
+
+    public async down(queryRunner: QueryRunner): Promise<void> {
+        await queryRunner.query(`ALTER TABLE "blog" DROP CONSTRAINT "UQ_0dc7e58d73a1390874a663bd599"`);
+        await queryRunner.query(`ALTER TABLE "blog" DROP COLUMN "slug"`);
+    }
+
+}

--- a/src/resolvers/blogResolver.ts
+++ b/src/resolvers/blogResolver.ts
@@ -52,6 +52,7 @@ export class BlogResolver {
     @Ctx() context: { userFromToken: { userId: string; email: string } },
     @Arg('name') name: string,
     @Arg('description') description: string,
+    @Arg('slug') slug: string,
     @Arg('template', { nullable: true }) template?: number
   ): Promise<Blog> {
     try {
@@ -63,6 +64,7 @@ export class BlogResolver {
       })
       const newBlog = new Blog()
       newBlog.name = name
+      newBlog.slug = slug
       newBlog.description = description
       newBlog.user = user
       newBlog.template = template === null ? template : 0


### PR DESCRIPTION
# TASK TO EPIC PR

## The feature / The problem
:sparkles:feat(e04-t08): add field slug to blogs

## Scope of my changes
entities/Blogs.ts
migration/

## Task
- [e04-t08:](https://www.notion.so/e04-t08_generation-slug-cfea3b9ec12a40aba1f15fec6fa93072)

## Type of change
- [x] New feature (feat)
- [ ] Fix issue (fix)
- [ ] Code refactorisation (refactor)
- [ ] Code testing (test)
- [ ] Add documentation (docs)


# Checklist
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my PR
- [x] I have removed not needed logs
- [x] I have remover TODO comments
- [ ] I have commented in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] I have been able to build my solution locally
- [x] My changes generate no new warnings
- [ ] New and existing unit tests pass locally with my changes
