### PR TITLE
feat(e03-t07): add delete user method in userResolver

### DIFF
--- a/src/resolvers/userResolver.ts
+++ b/src/resolvers/userResolver.ts
@@ -1,5 +1,5 @@
 import * as argon2 from 'argon2'
-import { UserInputError, AuthenticationError } from 'apollo-server'
+import { UserInputError, ApolloError, AuthenticationError } from 'apollo-server'
 import {
   Arg,
   Authorized,
@@ -154,5 +154,26 @@ export class UserResolver {
 
     const userFromDb = await dataSource.manager.save(User, user)
     return userFromDb
+  }
+
+  @Authorized()
+  @Mutation(() => String)
+  async deleteUser(
+    @Ctx() context: { userFromToken: { userId: string } }
+  ): Promise<String> {
+    try {
+      const {
+        userFromToken: { userId },
+      } = context
+      await dataSource.manager.findOneByOrFail(User, {
+        id: userId,
+      })
+      const deletedMessage = `Compte supprimé avec succès`
+      await dataSource.manager.delete(User, userId)
+      return deletedMessage
+    } catch (err) {
+      console.error(err)
+      throw new ApolloError('Impossible de supprimer le comtpe')
+    }
   }
 }


### PR DESCRIPTION
# TASK TO EPIC PR

## The feature / The problem
A user must be able to delete his account

## What I've done / The solution
Add delete user method in UserResolver

## Scope of my changes
src/resolvers/userResolver.ts

## Task
- [e03-t07](https://www.notion.so/e03-t07_profile-delete-2de9dd2838094e5880d904da7323038f)

## Type of change
- [x] New feature (feat)
- [ ] Fix issue (fix)
- [ ] Code refactorisation (refactor)
- [ ] Code testing (test)
- [ ] Add documentation (docs)


# Checklist
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my PR
- [x] I have removed not needed logs
- [x] I have remover TODO comments
- [ ] I have commented in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] I have been able to build my solution locally
- [x] My changes generate no new warnings
- [ ] New and existing unit tests pass locally with my changes

# Communication