### PR TITLE
feat(e06-t01): limits and offsets on blogs and articles, getNumberOfB…

### DIFF
--- a/src/resolvers/articleResolver.ts
+++ b/src/resolvers/articleResolver.ts
@@ -247,8 +247,8 @@ export class ArticleResolver {
   @Query(() => Number)
   async getNumberOfArticles(): Promise<number> {
     try {
-      const articles = await dataSource.manager.find(Article)
-      return articles.length
+      const count = await dataSource.getRepository(Article).count()
+      return count
     } catch (err) {
       console.log(err)
       throw new Error('Could not retreive number of articles')

--- a/src/resolvers/articleResolver.ts
+++ b/src/resolvers/articleResolver.ts
@@ -219,6 +219,42 @@ export class ArticleResolver {
     }
   }
 
+  @Query(() => [Article])
+  async getAllArticles(
+    @Arg('limit', { nullable: true }) limit?: number,
+    @Arg('offset', { nullable: true }) offset?: number,
+    @Arg('version', { nullable: true }) version?: number
+  ): Promise<Article[]> {
+    try {
+      const articles = await dataSource.manager.find(Article, {
+        relations: {
+          articleContent: true,
+        },
+        where: {
+          show: true,
+          version,
+        },
+        take: limit,
+        skip: offset,
+      })
+
+      return articles
+    } catch (error) {
+      throw new Error('Article not found')
+    }
+  }
+
+  @Query(() => Number)
+  async getNumberOfArticles(): Promise<number> {
+    try {
+      const articles = await dataSource.manager.find(Article)
+      return articles.length
+    } catch (err) {
+      console.log(err)
+      throw new Error('Could not retreive number of articles')
+    }
+  }
+
   @Authorized()
   @Mutation(() => Article)
   async updateArticle(

--- a/src/resolvers/blogResolver.ts
+++ b/src/resolvers/blogResolver.ts
@@ -17,6 +17,7 @@ export class BlogResolver {
           user: {
             blogs: true,
           },
+          articles: true,
         },
       })
       return blog
@@ -26,19 +27,37 @@ export class BlogResolver {
   }
 
   @Query(() => [Blog])
-  async getAllBlogs(): Promise<Blog[]> {
+  async getAllBlogs(
+    @Arg('limit', { nullable: true }) limit?: number,
+    @Arg('offset', { nullable: true }) offset?: number
+  ): Promise<Blog[]> {
     try {
       const blogs = await dataSource.manager.find(Blog, {
         relations: {
           user: {
             blogs: true,
           },
+          articles: true,
         },
+        take: limit,
+        skip: offset,
       })
+
       return blogs
     } catch (error) {
       console.error(error)
       throw new Error('Something went wrong')
+    }
+  }
+
+  @Query(() => Number)
+  async getNumberOfBlogs(): Promise<number> {
+    try {
+      const blogs = await dataSource.manager.find(Blog)
+      return blogs.length
+    } catch (err) {
+      console.log(err)
+      throw new Error('Could not retreive number of blogs')
     }
   }
 

--- a/src/resolvers/blogResolver.ts
+++ b/src/resolvers/blogResolver.ts
@@ -53,8 +53,8 @@ export class BlogResolver {
   @Query(() => Number)
   async getNumberOfBlogs(): Promise<number> {
     try {
-      const blogs = await dataSource.manager.find(Blog)
-      return blogs.length
+      const count = await dataSource.getRepository(Blog).count()
+      return count
     } catch (err) {
       console.log(err)
       throw new Error('Could not retreive number of blogs')


### PR DESCRIPTION
# TASK TO EPIC PR
(Delete if no relevant)

## The feature / The problem
I can set a limit and an offset on my getAllBlogs and getAllArticles queries
I can get the total number of blogs and articles

## What I've done / The solution
- Add limit and offset arguments to getAllBlogs and getAllArticles queries
- Add two new queries : getNumberOfBlogs and getNumberOfArticles

## Scope of my changes
- blogResolver
- articleResolver

## Task
- [e06-t01:]

## Type of change
- [x] New feature (feat)
- [ ] Fix issue (fix)
- [ ] Code refactorisation (refactor)
- [ ] Code testing (test)
- [ ] Add documentation (docs)


# Checklist
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my PR
- [x] I have removed not needed logs
- [x] I have remover TODO comments
- [ ] I have commented in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] I have been able to build my solution locally
- [x] My changes generate no new warnings
- [ ] New and existing unit tests pass locally with my changes

# Communication
Something special like a warning about this PR