### PR TITLE
fix epic05: query one blog without articles works again

### DIFF
--- a/src/resolvers/blogResolver.ts
+++ b/src/resolvers/blogResolver.ts
@@ -13,7 +13,6 @@ export class BlogResolver {
       const blog = await dataSource.manager.findOneOrFail(Blog, {
         where: {
           slug,
-          articles: { show: true },
         },
         relations: {
           user: {
@@ -24,6 +23,7 @@ export class BlogResolver {
       })
       return blog
     } catch (error) {
+      console.error(error)
       throw new Error('Something went wrong')
     }
   }


### PR DESCRIPTION
# TASK TO EPIC PR
(Delete if no relevant)

## The feature / The problem
Fix error when query blogs with no articles

## What I've done / The solution
Description of what I did/modified

## Scope of my changes
Add the name of the files you just worked on.
e.g. login.tsx / index.js / etc.

## Task
- [e00-t00:](link to issue)

## Type of change
- [ ] New feature (feat)
- [ ] Fix issue (fix)
- [ ] Code refactorisation (refactor)
- [ ] Code testing (test)
- [ ] Add documentation (docs)


# Checklist
- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my PR
- [ ] I have removed not needed logs
- [ ] I have remover TODO comments
- [ ] I have commented in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have been able to build my solution locally
- [ ] My changes generate no new warnings
- [ ] New and existing unit tests pass locally with my changes

# Communication
Something special like a warning about this PR

---

# EPIC TO STAGING PR
(Delete if no relevant)

## The EPIC feature
Short description of the Epic and its purpose.

## Type of change
- [ ] New feature (feat)
- [ ] Fix issue (fix)
- [ ] Code refactorisation (refactor)
- [ ] Code testing (test)
- [ ] Add documentation (docs)


# Checklist
- [ ] I have performed a self-review of my PR
- [ ] I have been able to build my solution locally
- [ ] New and existing unit tests pass locally with my changes

# Communication
Something special like a warning about this PR

---

# STAGING TO MAIN PR
(Delete if no relevant)

## Features added
Description of all the modifications that will be added

# Communication
Something special like a warning about this PR
